### PR TITLE
Securely wipe capsule data

### DIFF
--- a/components/icf/include/sodium.h
+++ b/components/icf/include/sodium.h
@@ -1,6 +1,7 @@
 #ifndef SODIUM_H
 #define SODIUM_H
 #include <stdint.h>
+#include <stddef.h>
 #include <openssl/sha.h>
 #define crypto_hash_sha256_BYTES 32
 static inline int crypto_hash_sha256(uint8_t *out, const uint8_t *in, unsigned long long inlen) {
@@ -10,5 +11,12 @@ static inline int crypto_hash_sha256(uint8_t *out, const uint8_t *in, unsigned l
 static inline int crypto_sign_verify_detached(const unsigned char *sig, const unsigned char *m, unsigned long long mlen, const unsigned char *pk) {
     (void)sig; (void)m; (void)mlen; (void)pk;
     return -1; // not implemented, always fail
+}
+
+static inline void sodium_memzero(void *p, size_t len) {
+    volatile unsigned char *vp = (volatile unsigned char *)p;
+    while (len--) {
+        *vp++ = 0;
+    }
 }
 #endif // SODIUM_H

--- a/components/icf/src/icf.c
+++ b/components/icf/src/icf.c
@@ -147,11 +147,21 @@ bool icf_verify(const icf_capsule_t *capsule, const uint8_t pubkey[32])
 
 void icf_capsule_free(icf_capsule_t *capsule)
 {
-    if (capsule && capsule->payload) {
+    if (!capsule) {
+        return;
+    }
+
+    if (capsule->payload) {
+        sodium_memzero(capsule->payload, capsule->payload_len);
         free(capsule->payload);
         capsule->payload = NULL;
         capsule->payload_len = 0;
     }
+
+    sodium_memzero(capsule->hash, sizeof(capsule->hash));
+    sodium_memzero(capsule->signature, sizeof(capsule->signature));
+    capsule->has_hash = false;
+    capsule->has_signature = false;
 }
 
 void icf_capsule_print(const icf_capsule_t *capsule)


### PR DESCRIPTION
## Summary
- wipe sensitive payload memory before freeing
- clear stored hash and signature when capsules are released
- provide simple `sodium_memzero` implementation in stub header

## Testing
- `gcc -Icomponents/icf/include -Itests tests/test_icf.c components/icf/src/icf.c -o tests/test_icf -lcrypto -lssl`
- `./tests/test_icf`


------
https://chatgpt.com/codex/tasks/task_e_6888cd514dcc8333abe462cc9a99ef9c