### PR TITLE
Add READ_U32_BE macro for expires parsing

### DIFF
--- a/components/icf/include/icf/icf.h
+++ b/components/icf/include/icf/icf.h
@@ -6,6 +6,13 @@
 #include <stdbool.h>
 #include "esp_err.h"
 
+/** Read a 32-bit unsigned integer encoded in big-endian order */
+#define READ_U32_BE(ptr) \
+    (((uint32_t)((const uint8_t *)(ptr))[0] << 24) | \
+     ((uint32_t)((const uint8_t *)(ptr))[1] << 16) | \
+     ((uint32_t)((const uint8_t *)(ptr))[2] << 8)  | \
+     ((uint32_t)((const uint8_t *)(ptr))[3]))
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/components/icf/src/icf.c
+++ b/components/icf/src/icf.c
@@ -55,8 +55,7 @@ esp_err_t icf_parse(const uint8_t *buffer, size_t len, icf_capsule_t *capsule)
             break;
         case ICF_TLV_EXPIRES:
             if (tlv_len != 4) return ESP_ERR_INVALID_SIZE;
-            capsule->expires = ((uint32_t)value[0] << 24) | ((uint32_t)value[1] << 16) |
-                               ((uint32_t)value[2] << 8) | value[3];
+            capsule->expires = READ_U32_BE(value);
             break;
         case ICF_TLV_BADGE_TYPE:
             if (tlv_len != 1) return ESP_ERR_INVALID_SIZE;


### PR DESCRIPTION
## Summary
- add utility macro `READ_U32_BE` for big-endian 32-bit reads
- use the new macro when parsing the `expires` field

## Testing
- `gcc -std=c99 -Icomponents/icf/include tests/test_icf.c components/icf/src/icf.c -lcrypto -o tests/test_icf && ./tests/test_icf`

------
https://chatgpt.com/codex/tasks/task_e_6888ce49e4c083338416e8cce650ce08