### PR TITLE
Add injectable signature verification

### DIFF
--- a/components/icf/include/icf/icf.h
+++ b/components/icf/include/icf/icf.h
@@ -80,6 +80,13 @@ bool icf_verify(const icf_capsule_t *capsule, const uint8_t pubkey[32]);
 void icf_capsule_print(const icf_capsule_t *capsule);
 void icf_capsule_free(icf_capsule_t *capsule);
 
+typedef int (*icf_verify_func_t)(const unsigned char *sig,
+                                 const unsigned char *m,
+                                 unsigned long long mlen,
+                                 const unsigned char *pk);
+
+void icf_set_verify_func(icf_verify_func_t func);
+
 #ifdef __cplusplus
 }
 #endif

--- a/components/icf/src/icf.c
+++ b/components/icf/src/icf.c
@@ -11,6 +11,13 @@
 #define ICF_FREE free
 #endif
 
+static icf_verify_func_t verify_func = crypto_sign_verify_detached;
+
+void icf_set_verify_func(icf_verify_func_t func)
+{
+    verify_func = func ? func : crypto_sign_verify_detached;
+}
+
 static esp_err_t parse_tlv_url(icf_capsule_t *capsule,
                                const uint8_t *value, uint8_t len)
 {
@@ -176,7 +183,7 @@ bool icf_verify(const icf_capsule_t *capsule, const uint8_t pubkey[32])
     if (!capsule || !pubkey || !capsule->has_signature || !capsule->has_hash) {
         return false;
     }
-    if (crypto_sign_verify_detached(capsule->signature, capsule->hash, 32, pubkey) == 0) {
+    if (verify_func(capsule->signature, capsule->hash, 32, pubkey) == 0) {
         return true;
     }
     return false;


### PR DESCRIPTION
## Summary
- add a callback to inject a signature verification function
- use injected callback from `icf_verify`
- test signature verification via a mock implementation

## Testing
- `gcc tests/test_icf.c components/icf/src/icf.c -Icomponents/icf/include -include tests/malloc_stub.h -DICF_MALLOC=test_malloc -o run_tests -lcrypto && ./run_tests`

------
https://chatgpt.com/codex/tasks/task_e_6888d6e6618c8333be61a3eab53bc78d