### PR TITLE
Fix cleanup of authority data

### DIFF
--- a/components/icf/src/icf.c
+++ b/components/icf/src/icf.c
@@ -206,6 +206,8 @@ void icf_capsule_free(icf_capsule_t *capsule)
     sodium_memzero(capsule->signature, sizeof(capsule->signature));
     capsule->has_hash = false;
     capsule->has_signature = false;
+    sodium_memzero(capsule->authority_id, sizeof(capsule->authority_id));
+    capsule->has_authority = false;
 }
 
 void icf_capsule_print(const icf_capsule_t *capsule)


### PR DESCRIPTION
## Summary
- wipe authority ID when freeing a capsule
- reset `has_authority` flag accordingly

## Testing
- `gcc tests/test_icf.c components/icf/src/icf.c -Icomponents/icf/include -Itests -include tests/malloc_stub.h -lcrypto -o tests/test_icf -DICF_MALLOC=test_malloc && ./tests/test_icf`

------
https://chatgpt.com/codex/tasks/task_e_6888d84c30748333bb048d8b61d20ad1