### PR TITLE
Add JSON parsing helper for system payload

### DIFF
--- a/components/icf/include/icf/icf.h
+++ b/components/icf/include/icf/icf.h
@@ -4,6 +4,9 @@
 #include <stdint.h>
 #include <stddef.h>
 #include <stdbool.h>
+#ifdef ICF_ENABLE_JSON
+#include <cjson/cJSON.h>
+#endif
 #include "esp_err.h"
 
 /** Read a 32-bit unsigned integer encoded in big-endian order */
@@ -86,6 +89,17 @@ typedef int (*icf_verify_func_t)(const unsigned char *sig,
                                  const unsigned char *pk);
 
 void icf_set_verify_func(icf_verify_func_t func);
+
+#ifdef ICF_ENABLE_JSON
+/**
+ * @brief Parse the JSON system payload into a cJSON object.
+ *
+ * The caller takes ownership of the returned object and must free it
+ * using cJSON_Delete(). NULL is returned if the capsule has no payload
+ * or if parsing fails.
+ */
+cJSON *icf_payload_to_json(const icf_capsule_t *capsule);
+#endif
 
 #ifdef __cplusplus
 }

--- a/components/icf/src/icf.c
+++ b/components/icf/src/icf.c
@@ -2,6 +2,9 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sodium.h>
+#ifdef ICF_ENABLE_JSON
+#include <cjson/cJSON.h>
+#endif
 #include "icf/icf.h"
 
 #ifndef ICF_MALLOC
@@ -234,4 +237,15 @@ void icf_capsule_print(const icf_capsule_t *capsule)
         printf("Signature present\n");
     }
 }
+
+#ifdef ICF_ENABLE_JSON
+cJSON *icf_payload_to_json(const icf_capsule_t *capsule)
+{
+    if (!capsule || !capsule->payload) {
+        return NULL;
+    }
+    return cJSON_ParseWithLength((const char *)capsule->payload,
+                                 capsule->payload_len);
+}
+#endif
 

--- a/tests/test_icf.c
+++ b/tests/test_icf.c
@@ -1,5 +1,6 @@
 #include "unity.h"
 #include "icf/icf.h"
+#include <cjson/cJSON.h>
 #include <sodium.h>
 #include <string.h>
 #include <stdlib.h>
@@ -222,6 +223,20 @@ void test_invalid_payload_nomem(void)
     TEST_ASSERT_EQUAL(ESP_ERR_NO_MEM, icf_parse(capsule, sizeof(capsule), &cap));
 }
 
+void test_json_payload_parse(void)
+{
+    const uint8_t capsule[] = {
+        0xE1,0x07,'{','"','a','"',':','1','}',
+        0xFF,0x00
+    };
+    icf_capsule_t cap;
+    TEST_ASSERT_EQUAL(ESP_OK, icf_parse(capsule, sizeof(capsule), &cap));
+    cJSON *json = icf_payload_to_json(&cap);
+    assert(json != NULL);
+    cJSON_Delete(json);
+    icf_capsule_free(&cap);
+}
+
 void test_invalid_hash_length(void)
 {
     uint8_t capsule[20];
@@ -275,6 +290,7 @@ int main(void)
     test_invalid_expires_size();
     test_invalid_badge_size();
     test_invalid_payload_nomem();
+    test_json_payload_parse();
     test_invalid_hash_length();
     test_invalid_signature_length();
     test_invalid_authority_length();


### PR DESCRIPTION
## Summary
- add optional `icf_payload_to_json` API guarded by `ICF_ENABLE_JSON`
- implement helper using cJSON
- extend unit tests with JSON payload parsing

## Testing
- `gcc -Icomponents/icf/include -Itests -include tests/malloc_stub.h -DICF_MALLOC=test_malloc -DICF_ENABLE_JSON tests/test_icf.c components/icf/src/icf.c -lcrypto -lcjson -o tests/test_runner && ./tests/test_runner`

------
https://chatgpt.com/codex/tasks/task_e_6888d94737c08333889930e90a6f1b78