### PR TITLE
Implement dynamic public key lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,24 @@ esp_err_t res = icf_parse_strict(
 
 ---
 
+## 🔑 Lookup dynamique de clé publique
+
+```c
+const uint8_t* my_lookup(const uint8_t id[8]) {
+    // retourner la clé correspondant à `id` ou NULL
+}
+
+esp_err_t res = icf_parse_lookup(
+    capsule_data,
+    capsule_len,
+    &capsule,
+    true,
+    my_lookup
+);
+```
+
+---
+
 ## 🧪 Lancer les tests
 
 Depuis le dossier `test/`, lancez :

--- a/include/icf/icf.h
+++ b/include/icf/icf.h
@@ -77,6 +77,23 @@ esp_err_t icf_parse(const uint8_t *buffer, size_t len, icf_capsule_t *capsule);
  */
 esp_err_t icf_parse_strict(const uint8_t *buffer, size_t len,
                            const uint8_t pubkey[32], icf_capsule_t *capsule);
+
+/** Lookup function returning the public key for an authority. */
+typedef const uint8_t *(*icf_pubkey_lookup_func_t)(const uint8_t authority_id[8]);
+
+/**
+ * Parse a capsule and, optionally, verify it using a dynamic
+ * public key lookup based on the authority_id field.
+ *
+ * When `strict` is true, the capsule must contain a signature and
+ * an authority identifier. The lookup function is used to retrieve
+ * the public key corresponding to this identifier and the signature
+ * is then verified. If lookup fails (NULL) or verification fails,
+ * an error is returned.
+ */
+esp_err_t icf_parse_lookup(const uint8_t *buffer, size_t len,
+                          icf_capsule_t *capsule, bool strict,
+                          icf_pubkey_lookup_func_t lookup);
 bool icf_verify(const icf_capsule_t *capsule, const uint8_t pubkey[32]);
 void icf_capsule_print(const icf_capsule_t *capsule);
 void icf_capsule_free(icf_capsule_t *capsule);


### PR DESCRIPTION
## Summary
- add `icf_parse_lookup` API for authority-based pubkey retrieval
- document dynamic lookup usage
- implement `icf_parse_lookup` and hook into tests
- add unit tests verifying lookup path

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a55ebce288333bc0ee12f70344926