### PR TITLE
Add enums for cycle and subject

### DIFF
--- a/include/icf/icf.h
+++ b/include/icf/icf.h
@@ -41,11 +41,40 @@ typedef enum {
     ICF_BADGE_ADMIN         = 0x02
 } icf_badge_type_t;
 
+/**
+ * @brief Cycle pedagogique selon SPEC-ICF
+ */
+typedef enum {
+    ICF_CYCLE_UNDEFINED    = 0x00,
+    ICF_CYCLE_1_MATERNELLE = 0x01,
+    ICF_CYCLE_2_CPC2       = 0x02,
+    ICF_CYCLE_3_CM16E      = 0x03,
+    ICF_CYCLE_4_543E       = 0x04,
+    ICF_CYCLE_LOCAL        = 0xFE,
+    ICF_CYCLE_RESERVED     = 0xFF,
+} icf_cycle_t;
+
+/**
+ * @brief Matière pédagogique selon SPEC-ICF
+ */
+typedef enum {
+    ICF_SUBJECT_UNDEFINED = 0x00,
+    ICF_SUBJECT_READING   = 0x01,
+    ICF_SUBJECT_SCIENCE   = 0x02,
+    ICF_SUBJECT_MUSIC     = 0x03,
+    ICF_SUBJECT_FOREIGN   = 0x04,
+    ICF_SUBJECT_PROJECT   = 0x05,
+    ICF_SUBJECT_MATH      = 0x06,
+    ICF_SUBJECT_CIVIC     = 0x07,
+    ICF_SUBJECT_LOCAL     = 0xFE,
+    ICF_SUBJECT_RESERVED  = 0xFF,
+} icf_subject_t;
+
 /** Tag pedagogique */
 typedef struct {
-    uint8_t cycle;
-    uint8_t subject;
-    uint8_t sub;
+    icf_cycle_t cycle;
+    icf_subject_t subject;
+    uint8_t sub;  /**< Champ libre, non normalisé */
 } icf_tag_t;
 
 /** Capsule structure */
@@ -85,6 +114,10 @@ esp_err_t icf_parse(const uint8_t *buffer, size_t len, icf_capsule_t *capsule,
 bool icf_verify(const icf_capsule_t *capsule, const uint8_t pubkey[32]);
 void icf_capsule_print(const icf_capsule_t *capsule);
 void icf_capsule_free(icf_capsule_t *capsule);
+
+const char *icf_cycle_to_string(icf_cycle_t cycle);
+const char *icf_subject_to_string(icf_subject_t subject);
+const char *icf_tag_to_string(const icf_tag_t *tag);
 
 typedef int (*icf_verify_func_t)(const unsigned char *sig,
                                  const unsigned char *m,

--- a/src/icf.c
+++ b/src/icf.c
@@ -219,7 +219,7 @@ void icf_capsule_print(const icf_capsule_t *capsule)
     if (capsule->url[0]) printf("URL: %s\n", capsule->url);
     if (capsule->language[0]) printf("Language: %s\n", capsule->language);
     if (capsule->title[0]) printf("Title: %s\n", capsule->title);
-    printf("Tag: cycle=%u subject=%u sub=%u\n", capsule->tag.cycle, capsule->tag.subject, capsule->tag.sub);
+    printf("Tag: %s\n", icf_tag_to_string(&capsule->tag));
     if (capsule->retention) printf("Retention: %u\n", capsule->retention);
     if (capsule->expires) printf("Expires: %" PRIu32 "\n", capsule->expires);
     if (capsule->payload) {
@@ -244,4 +244,44 @@ cJSON *icf_payload_to_json(const icf_capsule_t *capsule)
     }
     return cJSON_ParseWithLength((const char *)capsule->payload,
                                  capsule->payload_len);
+}
+
+const char *icf_cycle_to_string(icf_cycle_t cycle)
+{
+    switch (cycle) {
+    case ICF_CYCLE_1_MATERNELLE: return "CYCLE_1_MATERNELLE";
+    case ICF_CYCLE_2_CPC2:      return "CYCLE_2_CPC2";
+    case ICF_CYCLE_3_CM16E:     return "CYCLE_3_CM16E";
+    case ICF_CYCLE_4_543E:      return "CYCLE_4_543E";
+    case ICF_CYCLE_LOCAL:       return "CYCLE_LOCAL";
+    case ICF_CYCLE_RESERVED:    return "CYCLE_RESERVED";
+    default:                    return "CYCLE_UNDEFINED";
+    }
+}
+
+const char *icf_subject_to_string(icf_subject_t subject)
+{
+    switch (subject) {
+    case ICF_SUBJECT_READING:  return "READING";
+    case ICF_SUBJECT_SCIENCE:  return "SCIENCE";
+    case ICF_SUBJECT_MUSIC:    return "MUSIC";
+    case ICF_SUBJECT_FOREIGN:  return "FOREIGN";
+    case ICF_SUBJECT_PROJECT:  return "PROJECT";
+    case ICF_SUBJECT_MATH:     return "MATH";
+    case ICF_SUBJECT_CIVIC:    return "CIVIC";
+    case ICF_SUBJECT_LOCAL:    return "LOCAL";
+    case ICF_SUBJECT_RESERVED: return "RESERVED";
+    default:                   return "UNDEFINED";
+    }
+}
+
+const char *icf_tag_to_string(const icf_tag_t *tag)
+{
+    static char buf[64];
+    if (!tag) return "(null)";
+    snprintf(buf, sizeof(buf), "%s|%s|%u",
+             icf_cycle_to_string(tag->cycle),
+             icf_subject_to_string(tag->subject),
+             tag->sub);
+    return buf;
 }

--- a/test/test_icf.c
+++ b/test/test_icf.c
@@ -198,8 +198,8 @@ TEST_CASE("icf_parse complete valid", "[icf]")
     TEST_ASSERT_EQUAL_STRING("url", cap.url);
     TEST_ASSERT_EQUAL_STRING("en", cap.language);
     TEST_ASSERT_EQUAL_STRING("title", cap.title);
-    TEST_ASSERT_EQUAL(1, cap.tag.cycle);
-    TEST_ASSERT_EQUAL(2, cap.tag.subject);
+    TEST_ASSERT_EQUAL(ICF_CYCLE_1_MATERNELLE, cap.tag.cycle);
+    TEST_ASSERT_EQUAL(ICF_SUBJECT_SCIENCE, cap.tag.subject);
     TEST_ASSERT_EQUAL(3, cap.tag.sub);
     TEST_ASSERT_EQUAL(0x07, cap.retention);
     TEST_ASSERT_EQUAL(256, cap.expires);
@@ -327,8 +327,8 @@ TEST_CASE("TLV: Tag pédagogique complet", "[icf]") {
     const uint8_t capsule[] = {0x04, 0x03, 0x01, 0x02, 0x11, 0xFF, 0x00};
     icf_capsule_t cap;
     TEST_ASSERT_EQUAL(ESP_OK, icf_parse(capsule, sizeof(capsule), &cap, false, NULL));
-    TEST_ASSERT_EQUAL_UINT8(0x01, cap.tag.cycle);
-    TEST_ASSERT_EQUAL_UINT8(0x02, cap.tag.subject);
+    TEST_ASSERT_EQUAL_UINT8(ICF_CYCLE_1_MATERNELLE, cap.tag.cycle);
+    TEST_ASSERT_EQUAL_UINT8(ICF_SUBJECT_SCIENCE, cap.tag.subject);
     TEST_ASSERT_EQUAL_UINT8(0x11, cap.tag.sub);
 }
 


### PR DESCRIPTION
## Summary
- add explicit enums for cycle and subject in `icf_tag_t`
- expose helpers to print tag values symbolically
- update capsule printing to use new helper
- adjust unit tests to use enum constants

## Testing
- `idf.py --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b2978fef88333933b4ae43318e0a2